### PR TITLE
Update SPDX License identifier with correct format

### DIFF
--- a/ovs_offload/common/utils.py
+++ b/ovs_offload/common/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # Copyright 2022-2024 Intel Corporation
-# SPDX-License-Identifier: Apache 2.0
+# SPDX-License-Identifier: Apache-2.0
 #
 # Common python APIs and utilities for Intel® Infrastructure Processing Unit (Intel® IPU)
 

--- a/ovs_offload/ovs_offload_lnw.py
+++ b/ovs_offload/ovs_offload_lnw.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # Copyright 2022-2024 Intel Corporation
-# SPDX-License-Identifier: Apache 2.0
+# SPDX-License-Identifier: Apache-2.0
 #
 # Python tool to setup Linux Networking with OVS Offload on Intel® Infrastructure Processing Unit (Intel® IPU)
 

--- a/ovs_offload/ovs_offload_lnw_v2.py
+++ b/ovs_offload/ovs_offload_lnw_v2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # Copyright 2022-2024 Intel Corporation
-# SPDX-License-Identifier: Apache 2.0
+# SPDX-License-Identifier: Apache-2.0
 #
 # Python tool to setup Linux Networking with OVS Offload on Intel® Infrastructure Processing Unit (Intel® IPU)
 

--- a/ovs_offload/ovs_offload_lnw_v3.py
+++ b/ovs_offload/ovs_offload_lnw_v3.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # Copyright 2022-2024 Intel Corporation
-# SPDX-License-Identifier: Apache 2.0
+# SPDX-License-Identifier: Apache-2.0
 #
 # Python tool to setup Linux Networking with OVS Offload on Intel® Infrastructure Processing Unit (Intel® IPU)
 


### PR DESCRIPTION
Updated the SPDX License Identifier from `Apache 2.0` to `Apache-2.0`